### PR TITLE
Properly construct the generated data

### DIFF
--- a/cli/build/index.js
+++ b/cli/build/index.js
@@ -60,6 +60,12 @@ run(async () => {
   // @type { quotes: Quote[], authors: Author[], tags: Tag[] }
   const db = parseDataFiles(DEST)
 
+  Object.keys(src).forEach(key => {
+    if (typeof db.key === 'undefined') {
+      db[key] = []
+    }
+  })
+
   // Apply transforms to the source data to create the generated data files
   // This will add computed properties that are not included in the source
   // data files.

--- a/cli/sync/README.md
+++ b/cli/sync/README.md
@@ -14,7 +14,7 @@ Before running this command, make sure you run the build command to create / upd
 ## Usage 
 
 ```sh
-$ node cli/syncData [<dataDir>] [..options]
+$ node cli/sync [<dataDir>] [..options]
 ```
 
 ## Options 

--- a/cli/sync/index.js
+++ b/cli/sync/index.js
@@ -33,7 +33,8 @@ try {
   await testConnection()
   log.newLine()
 
-  const dataFiles = parseDataFiles(dataDir.generated)
+  const dataSrc = args.d || args.dest || dataDir.generated
+  const dataFiles = parseDataFiles(dataSrc)
 
   // Connect to the database
   await client.connect()


### PR DESCRIPTION
In a new setup or if new data files are added, the generated data would have a different structure then the source data. This would lead to exception thrown later when building generated data.

Also, fix an issue with the sync command using a hard coded generated data path in ../generated. This would lead to an issue when the user was building the data to a different path.